### PR TITLE
backward incompatible, bugfix: change the meaning of fluentd_flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ None
 | `fluentd_config_fragment_dir` | path to `conf.d` directory | `{{ fluentd_config_dir }}/conf.d` |
 | `fluentd_service_name`        | service name of `fluentd` | `{{  __fluentd_service_name }}` |
 | `fluentd_plugin_dir`          | path to directory where local plugins reside | `{{ fluentd_config_dir }}/plugin` |
-| `fluentd_flags`               | optional command line flags for the service | `{{ __fluentd_flags }}` |
+| `fluentd_flags`               | flags for the service | `{{ __fluentd_flags }}` |
 | `fluentd_gem_bin`             | path to `fluent-gem`  | `{{ __fluentd_gem_bin }}` |
 | `fluentd_plugins_to_install`  | list of plug-in names to install | `[]` |
 | `fluentd_plugins_to_create`   | list of plug-ins to _create_ (see below) | `[]` |
@@ -224,7 +224,7 @@ for `fluent-plugin-elasticsearch`.
       Debian:
         - libmaxminddb-dev
       OpenBSD: []
-    fluentd_extra_packages: "{{ os_fluentd_extra_packages }}"
+    fluentd_extra_packages: "{{ os_fluentd_extra_packages[ansible_os_family] }}"
 
     os_language_ruby_package:
       FreeBSD: lang/ruby26
@@ -243,11 +243,17 @@ for `fluent-plugin-elasticsearch`.
     fluentd_extra_groups: tty,bin
 
     os_fluentd_flags:
-      FreeBSD: "-p {{ fluentd_plugin_dir }}"
-      Debian: "-p {{ fluentd_plugin_dir }}"
-      RedHat: ""
-      OpenBSD: "--daemon /var/run/fluentd/fluentd.pid --config {{ fluentd_config_file }} -p {{ fluentd_plugin_dir }}"
-    fluentd_flags: "{{ os_fluentd_flags[ansible_os_family] }} --log {{ fluentd_log_file }}"
+      FreeBSD: |
+        fluentd_flags="-p {{ fluentd_plugin_dir }} --log {{ fluentd_log_file }}"
+      Debian: |
+        TD_AGENT_LOG_FILE="{{ fluentd_log_file }}"
+        TD_AGENT_OPTIONS="-p {{ fluentd_plugin_dir }}"
+        STOPTIMEOUT=180
+      RedHat: |
+        TD_AGENT_LOG_FILE="{{ fluentd_log_file }}"
+        TD_AGENT_OPTIONS=""
+      OpenBSD: "--daemon /var/run/fluentd/fluentd.pid --config {{ fluentd_config_file }} -p {{ fluentd_plugin_dir }} --log {{ fluentd_log_file }}"
+    fluentd_flags: "{{ os_fluentd_flags[ansible_os_family] }}"
     os_fluentd_bin:
       OpenBSD: /usr/local/bin/fluentd26
       FreeBSD: "{{ __fluentd_bin }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,7 +113,7 @@
 - name: Install fluent plugins
   command: "{{ fluentd_gem_bin }} install {{ item }}"
   with_items: "{{ fluentd_plugins_to_install }}"
-  when: not ( gem_list.stdout | search(item) )
+  when: not ( gem_list.stdout | regex_search(item) )
   notify: Restart fluentd
 
 - assert:
@@ -193,7 +193,7 @@
     dest: "{{ fluentd_config_file }}"
     # XXX `--log /dev/null` prevents the validate command from poluting log
     # file and messing log file permission
-    validate: "{{ fluentd_bin }} --dry-run {{ fluentd_flags }} --log /dev/null --config %s"
+    validate: "{{ fluentd_bin }} --dry-run -p {{ fluentd_plugin_dir }} --log /dev/null --config %s"
   notify: Reload fluentd
 
 - name: Start fluentd

--- a/templates/Debian.default.j2
+++ b/templates/Debian.default.j2
@@ -1,4 +1,3 @@
 # Managed by ansible
-# This file is sourced by /bin/sh from /etc/init.d/td-agent
-# Options to pass to td-agent
-TD_AGENT_OPTIONS="{{ fluentd_flags }}"
+
+{{ fluentd_flags }}

--- a/templates/FreeBSD.rc.d.j2
+++ b/templates/FreeBSD.rc.d.j2
@@ -1,3 +1,3 @@
 # Managed by ansible
 
-fluentd_flags="{{ fluentd_flags }}"
+{{ fluentd_flags }}

--- a/templates/RedHat.sysconfig.j2
+++ b/templates/RedHat.sysconfig.j2
@@ -1,2 +1,3 @@
 # Managed by ansible
-TD_AGENT_OPTIONS="{{ fluentd_flags }}"
+
+{{ fluentd_flags }}

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -67,11 +67,17 @@
     fluentd_extra_groups: tty,bin
 
     os_fluentd_flags:
-      FreeBSD: "-p {{ fluentd_plugin_dir }}"
-      Debian: "-p {{ fluentd_plugin_dir }}"
-      RedHat: ""
-      OpenBSD: "--daemon /var/run/fluentd/fluentd.pid --config {{ fluentd_config_file }} -p {{ fluentd_plugin_dir }}"
-    fluentd_flags: "{{ os_fluentd_flags[ansible_os_family] }} --log {{ fluentd_log_file }}"
+      FreeBSD: |
+        fluentd_flags="-p {{ fluentd_plugin_dir }} --log {{ fluentd_log_file }}"
+      Debian: |
+        TD_AGENT_LOG_FILE="{{ fluentd_log_file }}"
+        TD_AGENT_OPTIONS="-p {{ fluentd_plugin_dir }}"
+        STOPTIMEOUT=180
+      RedHat: |
+        TD_AGENT_LOG_FILE="{{ fluentd_log_file }}"
+        TD_AGENT_OPTIONS=""
+      OpenBSD: "--daemon /var/run/fluentd/fluentd.pid --config {{ fluentd_config_file }} -p {{ fluentd_plugin_dir }} --log {{ fluentd_log_file }}"
+    fluentd_flags: "{{ os_fluentd_flags[ansible_os_family] }}"
     os_fluentd_bin:
       OpenBSD: /usr/local/bin/fluentd26
       FreeBSD: "{{ __fluentd_bin }}"

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -161,7 +161,9 @@ when "redhat"
     it { should be_mode 644 }
     it { should be_owned_by default_user }
     it { should be_grouped_into default_group }
-    its(:content) { should match(/^TD_AGENT_OPTIONS=" --log #{Regexp.escape(fluentd_log_file)}"$/) }
+    its(:content) { should match(/Managed by ansible/) }
+    its(:content) { should match(/^TD_AGENT_OPTIONS=""$/) }
+    its(:content) { should match(/^TD_AGENT_LOG_FILE="#{Regexp.escape(fluentd_log_file)}"$/) }
   end
 when "ubuntu"
   describe file("/etc/default/td-agent") do
@@ -169,7 +171,10 @@ when "ubuntu"
     it { should be_mode 644 }
     it { should be_owned_by default_user }
     it { should be_grouped_into default_group }
-    its(:content) { should match(/^TD_AGENT_OPTIONS="-p #{Regexp.escape(fluentd_plugin_dir)} --log #{Regexp.escape(fluentd_log_file)}"$/) }
+    its(:content) { should match(/Managed by ansible/) }
+    its(:content) { should match(/^TD_AGENT_OPTIONS="-p #{Regexp.escape(fluentd_plugin_dir)}"$/) }
+    its(:content) { should match(/^TD_AGENT_LOG_FILE="#{Regexp.escape(fluentd_log_file)}"$/) }
+    its(:content) { should match(/^STOPTIMEOUT=180$/) }
   end
 when "freebsd"
   describe file("/etc/rc.conf.d") do
@@ -184,6 +189,7 @@ when "freebsd"
     it { should be_mode 644 }
     it { should be_owned_by default_user }
     it { should be_grouped_into default_group }
+    its(:content) { should match(/Managed by ansible/) }
     its(:content) { should match(/^fluentd_flags="-p #{Regexp.escape(fluentd_plugin_dir)} --log #{Regexp.escape(fluentd_log_file)}"$/) }
   end
 end


### PR DESCRIPTION
fluentd_flags was command line flags for fluentd. this is not same
meaning of `*_flags` in other roles.

fluentd_flags is now the content of startup scripts, such as
/etc/sysconfig/td-agent.

bugfix: replace old search() with regex_search().